### PR TITLE
Fixed branch selection support for both Grunt and Rake

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -28,6 +28,9 @@ module.exports = function (grunt) {
   // grunt --port=9001 serve
   var port = grunt.option('port') || 9000;
 
+  // You can specify a branch or even a version by appending: --branch=tags/vx.y.z
+  var branch = grunt.option('branch') || 'master';
+
   grunt.initConfig({
     config: projectConfig,
     clean: {
@@ -54,7 +57,7 @@ module.exports = function (grunt) {
     },
     shell: {
       rake: {
-        command: "rake 'convert[<%= branch %>]'"
+        command: "rake 'convert["+branch+"]'"
       }
     },
     clean: {
@@ -108,9 +111,6 @@ module.exports = function (grunt) {
       }
     }
   });
-
-  // TODO Make this specific to the shell task
-  var branch = grunt.option('branch') || 'master';
 
   grunt.registerTask('server', [
     'connect:server',

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@
 desc "Convert LESS to SCSS"
 task :convert, [:branch] do |t, args|
   require './tasks/converter'
-  branch = args.key?(:branch) ? args[:branch] : 'master'
+  branch = args.has_key?(:branch) ? args[:branch] : 'master'
   Patternfly::Converter.new(:branch => branch).process_patternfly
 end
 

--- a/tasks/converter.rb
+++ b/tasks/converter.rb
@@ -17,7 +17,7 @@ module Patternfly
         :test_dir => 'tests/patternfly'
       }
       options = defaults.merge(options)
-      super(:repo => options[:repo], :cache_path => options[:cache_path])
+      super(:repo => options[:repo], :cache_path => options[:cache_path], :branch => options[:branch])
       @save_to = {:scss => 'sass'}
       @test_dir = options[:test_dir]
       get_trees(PATTERNFLY_LESS_ROOT, BOOTSTRAP_LESS_ROOT, 'components/bootstrap-select', 'components/bootstrap-combobox', 'tests')
@@ -400,6 +400,17 @@ module Patternfly
         contents.merge!(full_path_contents)
       end
       contents
+    end
+
+    # Override
+    def get_branch_sha
+      @branch_sha ||= begin
+        cmd = "git ls-remote #{Shellwords.escape "https://github.com/#@repo"} #@branch"
+        log cmd
+        result = %x[#{cmd}]
+        raise 'Could not get branch sha!' unless $?.success? && !result.empty?
+        result.split(/\s+/).first
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds back the support to select an older version or a different branch when running the conversion. Because the older versions of patternfly had a variable ordering issue, the conversion will fail with `tags/v1.1.4`. 