### PR TITLE
Added rake upload task for uploading failure diffs to imgur

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ end
 group :test do
   gem 'rake'
   gem 'webrick'
+  gem 'imgur-api'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,13 @@ GEM
   specs:
     bootstrap-sass (3.1.1.0)
       sass (~> 3.2)
+    httparty (0.13.3)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    imgur-api (0.0.4)
+      httparty
+    json (1.8.2)
+    multi_xml (0.5.5)
     rake (10.4.2)
     sass (3.4.3)
     term-ansicolor (1.3.0)
@@ -15,6 +22,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass (= 3.1.1)
+  imgur-api
   rake
   sass (~> 3.2)
   term-ansicolor

--- a/Rakefile
+++ b/Rakefile
@@ -46,4 +46,17 @@ task :serve do
   server.start
 end
 
+task :upload do
+  require 'imgur'
+  require 'term/ansicolor'
+
+  client = Imgur.new ENV['IMGUR_ID']
+  images = Dir["tests/failures/*.png"].map { |img| client.upload Imgur::LocalImage.new(img, :title => img.sub('.png', '')) }
+
+  unless images.empty?
+    album = client.new_album(images, :title => "patternfly-sass build ##{ENV['TRAVIS_BUILD_NUMBER']} failures #{Time.now}")
+    puts Term::ANSIColor.bold "Failure image diffs uploaded to: #{Term::ANSIColor.red album.link}"
+  end
+end
+
 task default: :convert


### PR DESCRIPTION
The imgur client id should be stored in the IMGUR_ID environment variable.
This task should not be from a development machine, it's a dedicated Travis script.