### PR TITLE
Use Rack for running the test webserver.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,7 @@ rvm:
   - 2.0.0
 before_script:
   - bundle exec rake compile
-  - bundle exec rake serve > /dev/null 2>&1 &
-  - export PID=$!
-  - sleep 3
 script:
   - bundle exec rake spec
 after_failure:
   - bundle exec rake upload
-after_script:
-  - kill -2 $PID
-  - sleep 3

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 group :test do
   gem 'rake'
-  gem 'webrick'
+  gem 'thin'
   gem 'rspec'
   gem 'nokogiri'
   gem 'rmagick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,9 @@ GEM
     bootstrap-sass (3.3.4.1)
       autoprefixer-rails (>= 5.0.0.1)
       sass (>= 3.2.19)
+    daemons (1.2.2)
     diff-lcs (1.2.5)
+    eventmachine (1.0.7)
     execjs (2.5.2)
     font-awesome-sass (4.2.2)
       sass (~> 3.2)
@@ -21,6 +23,7 @@ GEM
     multi_xml (0.5.5)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
+    rack (1.6.1)
     rake (10.4.2)
     rmagick (2.15.0)
     rspec (3.2.0)
@@ -39,8 +42,11 @@ GEM
     sass (3.4.13)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
+    thin (1.6.3)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0)
+      rack (~> 1.0)
     tins (1.5.1)
-    webrick (1.3.1)
 
 PLATFORMS
   ruby
@@ -55,4 +61,4 @@ DEPENDENCIES
   rspec
   sass (~> 3.2)
   term-ansicolor
-  webrick
+  thin

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,17 @@
+require 'rack'
+
+url_map = {
+  '/'                => 'tests/',
+  '/less/dist'       => 'tests/patternfly/dist',
+  '/less/components' => 'components/patternfly/components',
+  '/less/patternfly' => 'tests/patternfly',
+  '/sass/dist/'      => 'tests/patternfly/dist',
+  '/sass/dist/css'   => 'dist/css',
+  '/sass/components' => 'components/patternfly/components',
+  '/sass/patternfly' => 'tests/patternfly',
+}
+url_map.each do |k, v|
+  url_map[k] = Rack::Directory.new(v)
+end
+
+run Rack::URLMap.new(url_map)

--- a/spec/compare_spec.rb
+++ b/spec/compare_spec.rb
@@ -1,14 +1,33 @@
 require 'net/http'
 require 'nokogiri'
 require 'rmagick'
+require 'thin'
 
-RSpec.describe "compare SASS with LESS screenshots" do
+describe "compare SASS with LESS screenshots" do
   BASEURL = "http://localhost:9000"
   RESOLUTIONS = [[320, 480], [768, 1024], [1280, 1024]]
   CONTEXTS = %w(less sass)
   TOLERANCE = 0.05
 
-  html = Net::HTTP.get(URI("#{BASEURL}/less/patternfly/index.html"))
+  before(:all) do
+    ['less', 'sass', 'failures'].each do |dir|
+      dest = File.join('tests', dir)
+      FileUtils.mkdir_p(dest)
+      FileUtils.rm(Dir.glob(File.join(dest, '*.png')))
+    end
+
+    app, _ = Rack::Builder.parse_file('config.ru')
+    @server = Thread.new do
+      Thin::Server.start('0.0.0.0', 9000, app)
+    end
+    sleep(2) # Give the server some time to start
+  end
+
+  after(:all) do
+    @server.kill unless @server.nil?
+  end
+
+  html = File.open(File.join("tests", "patternfly", "index.html"))
   document = Nokogiri::HTML(html)
 
   document.css(".row a").each do |link|
@@ -17,11 +36,13 @@ RSpec.describe "compare SASS with LESS screenshots" do
       title = file.sub('.html', '')
       RESOLUTIONS.each do |w,h|
         it "#{w}x#{h}" do
+          file_name = "#{title}-#{w}x#{h}.png"
           CONTEXTS.each do |ctx|
-            `phantomjs tests/capture.js #{w} #{h} #{BASEURL}/#{ctx}/patternfly/#{file} tests/#{ctx}/#{title}-#{w}x#{h}.png`
+            destination = File.join('tests', ctx, file_name)
+            `phantomjs tests/capture.js #{w} #{h} '#{BASEURL}/#{ctx}/patternfly/#{file}' #{destination}`
           end
-          img_less = Magick::Image.read("tests/less/#{title}-#{w}x#{h}.png").first
-          img_sass = Magick::Image.read("tests/sass/#{title}-#{w}x#{h}.png").first
+          img_less = Magick::Image.read(File.join('tests', 'less', file_name)).first
+          img_sass = Magick::Image.read(File.join('tests', 'sass', file_name)).first
 
           cols = [img_less.base_columns, img_sass.base_columns].max
           rows = [img_less.base_rows, img_sass.base_rows].max
@@ -32,7 +53,7 @@ RSpec.describe "compare SASS with LESS screenshots" do
 
           img_diff, diff_rate = img_less.compare_channel img_sass, Magick::MeanAbsoluteErrorMetric, Magick::AllChannels
 
-          img_diff.write("tests/failures/#{title}-#{w}x#{h}.png") unless diff_rate <= TOLERANCE
+          img_diff.write(File.join('tests', 'failures', file_name)) unless diff_rate <= TOLERANCE
           expect(diff_rate).to be <= TOLERANCE
         end
       end

--- a/tests/capture.js
+++ b/tests/capture.js
@@ -13,7 +13,11 @@ if (args.length === 5) {
   var page = require('webpage').create();
   page.viewportSize = { width: width, height: height };
   page.settings.resourceTimeout = 2000;
-  page.open(url, function() {
+  page.open(url, function(status) {
+    if (status == "fail") {
+      console.log("Opening " + url + " failed");
+      phantom.exit();
+    }
     page.evaluate(function() {
       var style = document.createElement('style');
       style.innerHTML = [


### PR DESCRIPTION
This patch lets the tests be completely self-sufficient.  You can now
just run them with `rspec spec/*spec.rb`.  Previously, the webserver
had to be started out of band.

Additionally this patch fixes an issue where PhantomJS was not
registering an error when it could not reach the test webpage.