### PR TITLE
Bootstrap version set to 3.3.4.1 because of a major change

### DIFF
--- a/patternfly-sass.gemspec
+++ b/patternfly-sass.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license  = 'Apache-2.0'
 
   s.add_runtime_dependency 'sass', '~> 3.2'
-  s.add_runtime_dependency 'bootstrap-sass', '~> 3.3.4'
+  s.add_runtime_dependency 'bootstrap-sass', '~> 3.3.4.1'
   s.add_runtime_dependency 'font-awesome-sass', '~> 4.3.0'
 
   # Converter's dependencies


### PR DESCRIPTION
Bootstrap changed the number of arguments for a mixin while incrementing only the patch version.
This commit sets the bootstrap-sass to 3.3.4.1 in the gemspec to fix this issue.