### PR TITLE
Added Travis build matrix with multiple tolerances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,11 @@ after_failure:
 after_script:
   - kill -2 $PID
   - sleep 2
+env:
+  matrix:
+    - "TOLERANCE=0.01"
+    - "TOLERANCE=0.00"
+matrix:
+  fast_finish: true
+  allow_failures:
+    - env: TOLERANCE=0.00

--- a/spec/compare_spec.rb
+++ b/spec/compare_spec.rb
@@ -7,10 +7,9 @@ RSpec.describe "compare SASS with LESS screenshots" do
   BASEURL = "http://localhost:9000"
   RESOLUTIONS = [[320, 480], [768, 1024], [1280, 1024]]
   CONTEXTS = %w(less sass)
+  TOLERANCE = ENV['TOLERANCE'].to_f || 0.00
 
-  # TODO: Set this to 0 when SASS 3.4.15 is released.
-  # See https://github.com/sass/sass/issues/1732
-  TOLERANCE = 0.05
+  puts "Starting tests with TOLERANCE=#{TOLERANCE}"
 
   driver = Selenium::WebDriver.for(:firefox)
 


### PR DESCRIPTION
- Tolerance inherited from the TOLERANCE environment variable, default is set to zero.
- In the build matrix the zero tolerance tests are allowed to fail.
- Base tolerance reduced to 0.01 for better results.