### PR TITLE
Move bootstrap and font-awesome dependency to main file

### DIFF
--- a/lib/patternfly-sass.rb
+++ b/lib/patternfly-sass.rb
@@ -74,6 +74,9 @@ module Patternfly
     end
 
     def register_rails_engine
+      require 'bootstrap-sass'
+      require 'font-awesome-sass'
+
       require 'patternfly-sass/engine'
     end
 

--- a/lib/patternfly-sass/engine.rb
+++ b/lib/patternfly-sass/engine.rb
@@ -1,6 +1,3 @@
-require 'bootstrap-sass'
-require 'font-awesome-sass'
-
 module Patternfly
   module Rails
     class Engine < ::Rails::Engine


### PR DESCRIPTION
This allows the `patternfly-sass/engine.rb` to be loaded without loading any external dependencies. In production scenarios that don't want to load the sass compiler, and just want to load the Engine, this makes that possible.