### PR TITLE
Update Rubocop file to remove warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,9 +48,7 @@ StringLiterals:
   # While this gives a marginal parse time speedup, it makes working with
   # strings annoying.
   Enabled: false
-TrailingComma:
+TrailingCommaInLiteral:
   Enabled: true
-UnneededPercentX:
-  Enabled: false
 WhileUntilModifier:
   Enabled: false


### PR DESCRIPTION
The old rule was occasionally crashing my linter. `UnneededPercentX` isn't recognized.